### PR TITLE
FreeBSD compile fix

### DIFF
--- a/ext/cityhash/city.cc
+++ b/ext/cityhash/city.cc
@@ -59,6 +59,12 @@ static uint32 UNALIGNED_LOAD32(const char *p) {
 #define bswap_32(x) OSSwapInt32(x)
 #define bswap_64(x) OSSwapInt64(x)
 
+#elif defined __FreeBSD__
+
+#include <sys/endian.h>
+#define bswap_32(x) bswap32(x)
+#define bswap_64(x) bswap64(x)
+
 #else
 
 #include <byteswap.h>


### PR DESCRIPTION
I'm only added this patch from FreeBSD ports, http://svnweb.freebsd.org/ports/head/devel/cityhash/files/patch-src_city.cc?view=markup , works for me.
