### PR TITLE
Fix C++ compilation on newer macOS/Xcode versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.9.1 (TBD) ##
+
+### bugfixes
+  * fix C++ compilation on newer macOS/Xcode versions by adding -std=c++11 flag
+
 ## 0.9.0 (October 11, 2017) ##
 
 ### enhancements

--- a/ext/cityhash/extconf.rb
+++ b/ext/cityhash/extconf.rb
@@ -8,4 +8,6 @@ RbConfig::MAKEFILE_CONFIG['CXX'] = cxx if cxx
   $CPPFLAGS += " #{flag}" unless $CPPFLAGS.split.include? flag
 end
 
+$CPPFLAGS += " -std=c++11"
+
 create_makefile('cityhash/cityhash')


### PR DESCRIPTION
This PR fixes compilation issues on newer macOS/Xcode versions by adding the -std=c++11 flag to resolve lambda expression compatibility issues with recent C++ standard library headers.

Changes:
- Add -std=c++11 flag in extconf.rb
- Update CHANGELOG.md with bug fix entry

Fixes compilation errors like:
```
error: expected expression
auto __cleanup = [](void* __p) { std::__destroy_at(static_cast<_Ep2*>(__p)); };
```